### PR TITLE
SANS instruments: sequencing of pixel ID's

### DIFF
--- a/SNS/SANS/utilities.py
+++ b/SNS/SANS/utilities.py
@@ -303,7 +303,7 @@ def add_curved_panel_type(det, num_elem, radius, dtheta, theta_0=0.,
     return type_assembly
 
 
-def add_double_curved_panel_type(det, iinfo):
+def add_double_curved_panel_type(det, iinfo, first_bank_number=1):
     r"""
     Create a type for the double curved panel using a type for the front
     and a type for the back  panels.
@@ -318,7 +318,8 @@ def add_double_curved_panel_type(det, iinfo):
         Options for the instrument. Assumed to contain the following
         keys: bank_radius, anchor_offset, fourpack_separation, fourpack_slip,
         number_eightpacks, eightpack_angle, curved_panel_types
-
+    first_bank_number: int
+        Start bank number with this one
     Returns
     -------
     lxml.etree.subelement
@@ -336,14 +337,15 @@ def add_double_curved_panel_type(det, iinfo):
             -iinfo['eightpack_angle']]
     # Insert type for front panel
     kwargs = dict(name_elem=iinfo['bank_name'], theta_0=slip_angle,
-                  assemb_type=iinfo['curved_panel_types']['front'])
+                  assemb_type=iinfo['curved_panel_types']['front'],
+                  first_index=first_bank_number)
     front = add_curved_panel_type(*args, **kwargs)
     # Insert type for back panel
     args = [det, iinfo['number_eightpacks'], r_eightpack + delta_r,
             -iinfo['eightpack_angle']]
     kwargs = dict(name_elem=iinfo['bank_name'], theta_0=-slip_angle,
                   assemb_type=iinfo['curved_panel_types']['back'],
-                  first_index=1+iinfo['number_eightpacks'])
+                  first_index=first_bank_number + iinfo['number_eightpacks'])
     back = add_curved_panel_type(*args, **kwargs)
     # Insert type for double panel
     add_comment_section(det, 'TYPE: DOUBLE CURVED PANEL')

--- a/SNS/SANS/utilities.py
+++ b/SNS/SANS/utilities.py
@@ -376,3 +376,47 @@ def add_double_curved_panel_component(double_panel, idlist, det, name):
     kwargs = dict(type=double_panel.attrib['name'], idlist=idlist, name=name)
     comp = le.SubElement(det.root, 'component', **kwargs)
     return comp
+
+
+def panel_idlist(iinfo, start=0, gap=0):
+    r"""
+    List of pixel ID's in a single panel
+    in suitable format for helper.addDetectorIds
+
+    Parameters
+    ----------
+    iinfo: dict
+        Options for the instrument. Assumed to contain the following
+        keys: pixels_per_tube, number_eightpacks
+    start: int
+        starting pixel ID for the panel
+    gap: int
+        pixel ID gap between consecutive panel elements (fourpacks)
+
+    Returns
+    -------
+    list
+        [(start1, end1, None), (start2, end2, None), ...]
+    """
+    fourpack = 4 * iinfo['pixels_per_tube']  # number of pixels in a fourpack
+    idlist = list()
+    s = start
+    for i in range(iinfo['number_eightpacks']):
+        idlist.extend([s, s + fourpack - 1, None])
+        s += fourpack + gap
+    return idlist
+
+
+def add_double_panel_idlist(det, iinfo, name, start=0):
+    r"""
+
+    Parameters
+    ----------
+    iinfo
+    start
+    """
+    add_comment_section(det, 'LIST OF PIXEL IDs in DETECTOR')
+    fourpack = 4 * iinfo['pixels_per_tube']  # number of pixels in a fourpack
+    front_list = panel_idlist(iinfo, start=start, gap=fourpack)
+    back_list = panel_idlist(iinfo, start=start + fourpack, gap=fourpack)
+    det.addDetectorIds(name, front_list + back_list)

--- a/biosans_geometry.py
+++ b/biosans_geometry.py
@@ -53,7 +53,7 @@ add_double_flat_panel_component(double_panel, 'flat_panel_ids', det,
                                 iinfo['flat_array'])
 add_double_panel_idlist(det, iinfo, pixel_idlist)
 last_pixel_id = 8 * iinfo['number_eightpacks'] * iinfo['pixels_per_tube'] - 1
-
+last_bank_number = 2 * iinfo['number_eightpacks']
 #
 # Insert the curved panel
 #
@@ -67,14 +67,14 @@ Explanation of some entries in jinfo dictionary
 jinfo = dict(curved_array='wing_detector_arm',  # name of the wing detector
              curved_panel_types=dict(front='front-wing-panel',
                                      back='back-wing-panel'),
-             bank_name='wing-bank',
              number_eightpacks=20,
              bank_radius=1.129538,
              anchor_offset=0.0,
              eightpack_angle=2.232094)
 
 iinfo.update(jinfo)
-double_panel = add_double_curved_panel_type(det, iinfo)
+kwargs = dict(first_bank_number = 1 + last_bank_number)
+double_panel = add_double_curved_panel_type(det, iinfo, **kwargs)
 pixel_idlist = 'curved_panel_ids'
 double_panel = add_double_curved_panel_component(double_panel,
                                                  pixel_idlist,

--- a/biosans_geometry.py
+++ b/biosans_geometry.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python3
 import math
 from helper import MantidGeom
-from SNS.SANS.utilities import (add_comment_section, kw, ag, make_filename,
-                                add_basic_types, add_double_flat_panel_type,
+from SNS.SANS.utilities import (kw, ag, make_filename, add_basic_types,
+                                add_double_flat_panel_type,
                                 add_double_flat_panel_component,
                                 add_double_curved_panel_type,
-                                add_double_curved_panel_component)
+                                add_double_curved_panel_component,
+                                add_double_panel_idlist)
 
 """
 Instrument requirements from meeting at HFIR on May 07, 2019
@@ -47,11 +48,12 @@ add_basic_types(det, iinfo)  # source, sample, pixel, tube, and fourpack
 # Insert the flat panel
 #
 double_panel = add_double_flat_panel_type(det, iinfo)
-add_comment_section(det, 'LIST OF PIXEL IDs in FLAT DETECTOR')
-n_flat_pixels = iinfo['number_eightpacks'] * 8 * 256
-det.addDetectorIds('flat_panel_ids', [0, n_flat_pixels - 1, 1])
+pixel_idlist = 'flat_panel_ids'
 add_double_flat_panel_component(double_panel, 'flat_panel_ids', det,
                                 iinfo['flat_array'])
+add_double_panel_idlist(det, iinfo, pixel_idlist)
+last_pixel_id = 8 * iinfo['number_eightpacks'] * iinfo['pixels_per_tube'] - 1
+
 #
 # Insert the curved panel
 #
@@ -73,17 +75,15 @@ jinfo = dict(curved_array='wing_detector_arm',  # name of the wing detector
 
 iinfo.update(jinfo)
 double_panel = add_double_curved_panel_type(det, iinfo)
-add_comment_section(det, 'LIST OF PIXEL IDs in CURVED DETECTOR')
-n_curved_pixels = iinfo['number_eightpacks'] * 8 * 256
-det.addDetectorIds('curved_panel_ids',
-                   [n_flat_pixels, n_flat_pixels + n_curved_pixels - 1, 1])
+pixel_idlist = 'curved_panel_ids'
 double_panel = add_double_curved_panel_component(double_panel,
-                                                 'curved_panel_ids',
+                                                 pixel_idlist,
                                                  det, iinfo['curved_array'])
 # Rotate the double panel away from the path of the Z-axis
 rot_y = - iinfo['eightpack_angle'] * iinfo['number_eightpacks'] / 2
 rot_y += 0.5 * iinfo['fourpack_slip'] / jinfo['bank_radius'] * 180. / math.pi
 det.addLocation(double_panel, 0., 0., 0, rot_y=rot_y)
+add_double_panel_idlist(det, iinfo, pixel_idlist, start=1 + last_pixel_id)
 
 #
 # Write to file

--- a/eqsans_geometry.py
+++ b/eqsans_geometry.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 from helper import MantidGeom
-from SNS.SANS.utilities import (add_comment_section, kw, ag, make_filename,
-                                add_basic_types, add_double_curved_panel_type,
-                                add_double_curved_panel_component)
+from SNS.SANS.utilities import (kw, ag, make_filename, add_basic_types,
+                                add_double_curved_panel_type,
+                                add_double_curved_panel_component,
+                                add_double_panel_idlist)
 
 """
 Instrument requirements from meeting at HFIR on May 07, 2019
@@ -75,15 +76,14 @@ if __name__ == '__main__':
     # Insert the curved panel
     #
     double_panel = add_double_curved_panel_type(det, iinfo)
-    add_comment_section(det, 'LIST OF PIXEL IDs in DETECTOR')
-    n_pixels = iinfo['number_eightpacks'] * 8 * 256
-    det.addDetectorIds('pixel_ids', [0, n_pixels - 1, 1])
+    pixel_idlist = 'pixel_ids'
     double_panel = add_double_curved_panel_component(double_panel,
-                                                     'pixel_ids',
+                                                     pixel_idlist,
                                                      det,
                                                      iinfo['curved_array'])
     r_eightpack = iinfo['bank_radius'] + iinfo['anchor_offset']
     det.addLocation(double_panel, 0., 0., -r_eightpack)  # position at origin
+    add_double_panel_idlist(det, iinfo, pixel_idlist)
     #
     # Write to file
     #

--- a/gpsans_geometry.py
+++ b/gpsans_geometry.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 from helper import MantidGeom
-from SNS.SANS.utilities import (add_comment_section, kw, ag, make_filename,
-                                add_basic_types, add_double_flat_panel_type,
-                                add_double_flat_panel_component)
+from SNS.SANS.utilities import (kw, ag, make_filename, add_basic_types,
+                                add_double_flat_panel_type,
+                                add_double_flat_panel_component,
+                                add_double_panel_idlist)
 
 """
 Instrument requirements from meeting at HFIR on May 07, 2019
@@ -16,6 +17,8 @@ iinfo = dict(valid_from='2019-01-01 00:00:00',
              comment='Created by Jose Borregero, borreguerojm@ornl.gov',
              instrument_name='GPSANS',
              source_sample_distance=1.0,
+             bank_name='bank',
+             flat_panel_types=dict(front='front-panel', back='back-panel'),
              flat_array='detector1',  # name of the detector array
              tube_length=1.046,
              tube_diameter=0.00805,
@@ -30,11 +33,13 @@ det = MantidGeom(iinfo['instrument_name'],
                  **kw(iinfo, 'comment', 'valid_from', 'valid_to'))
 det.addSnsDefaults(default_view="3D", axis_view_3d="Z-")
 fn = make_filename(*ag(iinfo, 'instrument_name', 'valid_from','valid_to'))
+#
+# Insert the flat panel
+#
 add_basic_types(det, iinfo)  # source, sample, pixel, tube, and fourpack
 double_panel = add_double_flat_panel_type(det, iinfo)
-add_comment_section(det, 'LIST OF PIXEL IDs')
-det.addDetectorIds('array_list',
-                    [0, iinfo['number_eightpacks'] * 8 * 256 - 1, 1])
-add_double_flat_panel_component(double_panel, 'array_list', det,
+pixel_idlist = 'pixel_ids'
+add_double_flat_panel_component(double_panel, pixel_idlist, det,
                                 iinfo['flat_array'])
+add_double_panel_idlist(det, iinfo, pixel_idlist)
 det.writeGeom(fn)


### PR DESCRIPTION
**To Test:**
1. Run script `eqsans_geometry.py` with python version >= 3.6 to create file `EQSANS_Definition_2019_2100.xml`.
2. Load `EQSANS_Definition_2019_2100.xml` in Mantid, then show instrument
3. Verify the pixel ID's follow the sequence defined in the description of #133

Note: `biosans_geometry.py` and `gpsans_geometry.py` will also create analogous IDF's but the sequence of pixels in the flat panels is most likely incorrect. It's inconsequential until the time when EPICS is implemented in these instruments.

Fixes #133