### PR TITLE
Set default view as Z- for ILL SANS

### DIFF
--- a/ILL/IDF/d11_generateIDF.py
+++ b/ILL/IDF/d11_generateIDF.py
@@ -7,14 +7,14 @@ sys.path.insert(0, path)
 from helper import MantidGeom
 
 # using metre as unit
-instrumentName = 'D11lr'
+instrumentName = 'D11'
 validFrom = "2017-10-01 23:59:59"
 moderator_source = -2.0
 # 2 Monitors
 zMon1 = -16.7
 zMon2 = -1.2
 # factor: 1 (lr), 2
-factor = 1
+factor = 2
 # definition of the quadratic detector
 numberPixelsVertical = 128 * factor
 numberPixelsHorizontal = 128 * factor

--- a/ILL/IDF/d11_generateIDF.py
+++ b/ILL/IDF/d11_generateIDF.py
@@ -7,14 +7,14 @@ sys.path.insert(0, path)
 from helper import MantidGeom
 
 # using metre as unit
-instrumentName = 'D11'
+instrumentName = 'D11lr'
 validFrom = "2017-10-01 23:59:59"
 moderator_source = -2.0
 # 2 Monitors
 zMon1 = -16.7
 zMon2 = -1.2
 # factor: 1 (lr), 2
-factor = 2
+factor = 1
 # definition of the quadratic detector
 numberPixelsVertical = 128 * factor
 numberPixelsHorizontal = 128 * factor
@@ -25,14 +25,14 @@ pixelHeight = 0.0075 / factor
 x = pixelWidth / 2.
 y = pixelHeight / 2.
 z = 0.
-thickness = repr(-0.0001)
+thickness = 0.0001
 # rear detector
 zPos = 1.2
 # start identification numbers
 id0 = repr(0)
 # rectangular detector
-xstart = repr(-pixelWidth * (numberPixelsHorizontal - 1) / 2)
-xstep = repr(pixelWidth)
+xstart = repr(pixelWidth * (numberPixelsHorizontal - 1) / 2)
+xstep = repr(-pixelWidth)
 xpixels = repr(numberPixelsHorizontal)
 ystart = repr(-pixelHeight * (numberPixelsVertical - 1) / 2)
 ystep = repr(pixelHeight)
@@ -83,7 +83,7 @@ comment = """ This is the instrument definition file of the D11 Lowest momentum 
        https://www.ill.eu/instruments-support/instruments-groups/instruments/d11/characteristics/
        """
 d11 = MantidGeom(instrumentName, comment=comment, valid_from=validFrom)
-d11.addSnsDefaults()
+d11.addSnsDefaults(default_view='3D',axis_view_3d='z-')
 d11.addComment("SOURCE")
 d11.addComponentILL("moderator", 0., 0., moderator_source, "Source")
 d11.addComment("Sample position")
@@ -99,5 +99,5 @@ d11.addComment("DETECTOR")
 d11.addComponentRectangularDetector(detector0, 0., 0., zPos, idstart=id0, idfillbyfirst=FF, idstepbyrow=SR)
 d11.addRectangularDetector(detector0, pixelName, xstart, xstep, xpixels, ystart, ystep, ypixels)
 d11.addComment("PIXEL, EACH PIXEL IS A DETECTOR")
-d11.addCuboidPixel(pixelName, [-x, -y, z], [x, y, z], [-x, -y, thickness], [x, -y, z], shape_id="pixel-shape")
+d11.addCuboidPixel(pixelName, [-x, -y, thickness/2.], [-x, y, thickness/2.], [-x, -y, -thickness/2.], [x, -y, thickness/2.], shape_id="pixel-shape")
 d11.writeGeom("./ILL/IDF/" + instrumentName + "_Definition.xml")

--- a/ILL/IDF/d22_generateIDF.py
+++ b/ILL/IDF/d22_generateIDF.py
@@ -25,7 +25,7 @@ pixelHeight = 0.008 / factor
 x = pixelWidth / 2.
 y = pixelHeight / 2.
 z = 0.
-thickness = repr(-0.0001)
+thickness = 0.0001
 # detector
 zPos = 12.8
 # start identification numbers
@@ -78,7 +78,7 @@ comment = """ This is the instrument definition file of the D22 Large dynamic ra
        https://www.ill.eu/instruments-support/instruments-groups/instruments/d22/characteristics/
        """
 d22 = MantidGeom(instrumentName, comment=comment, valid_from=validFrom)
-d22.addSnsDefaults()
+d22.addSnsDefaults(default_view='3D',axis_view_3d='z-')
 d22.addComment("SOURCE")
 d22.addComponentILL("moderator", 0., 0., moderator_source, "Source")
 d22.addComment("Sample position")
@@ -94,5 +94,5 @@ d22.addComment("DETECTOR")
 d22.addComponentRectangularDetector(detector0, 0., 0., zPos, idstart=id0, idfillbyfirst=FF, idstepbyrow=SR)
 d22.addRectangularDetector(detector0, pixelName, xstart, xstep, xpixels, ystart, ystep, ypixels)
 d22.addComment("PIXEL, EACH PIXEL IS A DETECTOR")
-d22.addCuboidPixel(pixelName, [-x, -y, z], [x, y, z], [-x, -y, thickness], [x, -y, z], shape_id="pixel-shape")
+d22.addCuboidPixel(pixelName, [-x, -y, thickness/2.], [-x, y, thickness/2.], [-x, -y, -thickness/2.], [x, -y, thickness/2.], shape_id="pixel-shape")
 d22.writeGeom("./ILL/IDF/" + instrumentName + "_Definition.xml")

--- a/ILL/IDF/d33_generateIDF.py
+++ b/ILL/IDF/d33_generateIDF.py
@@ -25,7 +25,7 @@ pixelHeight = 0.005
 x = pixelWidth / 2.
 y = pixelHeight / 2.
 z = 0.
-thickness = repr(-0.0001)
+thickness = 0.0001
 # rear detector
 zPosRear = 12.8
 # front detector
@@ -101,7 +101,7 @@ comment = """ This is the instrument definition file of the D33 Massive dynamic 
        https://www.ill.eu/instruments-support/instruments-groups/instruments/d33/characteristics/
        """
 d33 = MantidGeom(instrumentName, comment=comment, valid_from=validFrom)
-d33.addSnsDefaults()
+d33.addSnsDefaults(default_view='3D',axis_view_3d='z-')
 d33.addComment("SOURCE")
 d33.addComponentILL("moderator", 0., 0., moderator_source, "Source")
 d33.addComment("Sample position")
@@ -137,5 +137,5 @@ d33.addRectangularDetector(detector3, pixelName, xstart, xstep, xpixels, startFr
 d33.addComment("TOP")
 d33.addRectangularDetector(detector4, pixelName, xstart, xstep, xpixels, startFront, ystep, pixelsFront)
 d33.addComment("PIXEL, EACH PIXEL IS A DETECTOR")
-d33.addCuboidPixel(pixelName, [-x, -y, z], [x, y, z], [-x, -y, thickness], [x, -y, z], shape_id="pixel-shape")
+d33.addCuboidPixel(pixelName, [-x, -y, thickness/2.], [-x, y, thickness/2.], [-x, -y, -thickness/2.], [x, -y, -thickness/2.], shape_id="pixel-shape")
 d33.writeGeom("./ILL/IDF/" + instrumentName + "_Definition.xml")


### PR DESCRIPTION
- [x]  Sets the default view to Z-.
- [x]  Flips the wrong pixel numbering for D11 and D11lr.
- [x]  Corrects the definition of the standard pixel.