### PR TITLE
Update for D16 IDF generator 

### DIFF
--- a/ILL/IDF/d16_generateIDF.py
+++ b/ILL/IDF/d16_generateIDF.py
@@ -10,7 +10,7 @@ instrumentName = 'D16'
 validFrom = "2020-01-01 00:00:00"
 
 
-monochromator_source = 2.8
+monochromator_source = -2.8
 
 # 2 monitors
 zMon1 = 0

--- a/ILL/IDF/d16_generateIDF.py
+++ b/ILL/IDF/d16_generateIDF.py
@@ -99,11 +99,8 @@ d16.addDummyMonitor(0.01, 0.01)
 d16.addComment("MONITOR IDs")
 d16.addMonitorIds([repr(500000), repr(500001)])
 
-d16.addComment("DETECTORS")
-# d16.addComponentILL("detector", 0., 0., 0.)
-# detector = d16.makeTypeElement("detector")
-d16.addComponentRectangularDetector(detector0, 0., 0., -zPosDetector, idstart=id0, idfillbyfirst=FF, idstepbyrow=SR)
 d16.addComment("DETECTOR")
+d16.addComponentRectangularDetector(detector0, 0., 0., -zPosDetector, idstart=id0, idfillbyfirst=FF, idstepbyrow=SR)
 d16.addRectangularDetector(detector0, pixelName, xstart, xstep, xpixels, ystart, ystep, ypixels)
 
 d16.addComment("PIXEL, EACH PIXEL IS A DETECTOR")

--- a/ILL/IDF/d16_generateIDF.py
+++ b/ILL/IDF/d16_generateIDF.py
@@ -13,8 +13,8 @@ validFrom = "2020-01-01 00:00:00"
 monochromator_source = -2.8
 
 # 2 monitors
-zMon1 = 0
-zMon2 = 0
+zMon1 = -1
+zMon2 = -1.5
 
 # definition of the quadratic detector
 numberPixelsVertical = 320

--- a/ILL/IDF/d16_generateIDF.py
+++ b/ILL/IDF/d16_generateIDF.py
@@ -100,9 +100,9 @@ d16.addComment("MONITOR IDs")
 d16.addMonitorIds([repr(500000), repr(500001)])
 
 d16.addComment("DETECTORS")
-d16.addComponentILL("detector", 0., 0., 0.)
-detector = d16.makeTypeElement("detector")
-d16.addComponentRectangularDetector(detector0, 0., 0., -zPosDetector, idstart=id0, idfillbyfirst=FF, idstepbyrow=SR, root=detector)
+# d16.addComponentILL("detector", 0., 0., 0.)
+# detector = d16.makeTypeElement("detector")
+d16.addComponentRectangularDetector(detector0, 0., 0., -zPosDetector, idstart=id0, idfillbyfirst=FF, idstepbyrow=SR)
 d16.addComment("DETECTOR")
 d16.addRectangularDetector(detector0, pixelName, xstart, xstep, xpixels, ystart, ystep, ypixels)
 


### PR DESCRIPTION
Some small changes to the IDF generator of D16 : 
- removed the detectors grouping, as there is only one detector
- flipped the pixel ordering along the x-axis, to correspond to reality
- moved the monochromator so the sample is now between it and the detector
- set the monitors between the monochromator and the sample