### PR TITLE
Add an axis for TwoThetaSigned

### DIFF
--- a/ILL/IDF/d16_generateIDF.py
+++ b/ILL/IDF/d16_generateIDF.py
@@ -83,7 +83,7 @@ comment = """
 
 # Instrument creation
 d16 = MantidGeom(instrumentName, comment=comment, valid_from=validFrom)
-d16.addSnsDefaults(default_view='3D', axis_view_3d='z-')
+d16.addSnsDefaults(default_view='3D', axis_view_3d='z-', theta_sign_axis="x")
 
 d16.addComment("SOURCE")
 d16.addComponentILL("monochromator", 0., 0., monochromator_source, "Source")


### PR DESCRIPTION
Added axis definition to determine the two theta sign required by ConvertSpectrumAxis to correctly calculate the twoTheta of D16 pixels.

Closes #169 