### PR TITLE
Corrected L1 distances for SHARP

### DIFF
--- a/ILL/IDF/sharp_generateIDF.py
+++ b/ILL/IDF/sharp_generateIDF.py
@@ -18,14 +18,14 @@ instrumentName = 'SHARP'
 numberOfTubes = 240
 numberOfPixelsPerTube = 256
 firstDetectorId = 1
-l1 = 3.3
+l1 = 0.551
 l2 = 2.5
 pixelRadius = 0.0127
 tubeHeight = float(args.TubeHeight)
 equator = float(args.EquatorialPixel)
 pixelHeight = tubeHeight / numberOfPixelsPerTube
 tubeVerticalShift = (numberOfPixelsPerTube / 2 - equator) * pixelHeight
-monitorZ = -0.533
+monitorZ = -0.362
 
 pixelSpacingDegrees = 0.605
 tubeAngles = np.linspace(0., (numberOfTubes-1)*pixelSpacingDegrees, numberOfTubes)


### PR DESCRIPTION
During a work on benchmarking ILL instrument SHARP energy calibration, it was found that the values provided were consistently wrong in comparison with the running parameters of that instrument. The issue was narrowed down to the incorrect values of the L1 distances, namely the distance from the Fermi chopper to the sample, and the monitor to the sample. This PR corrects these values to those provided by a scientist responsible for SHARP.